### PR TITLE
Fix CSI code to end bracketed paste mode.

### DIFF
--- a/src/ui/terminal/keys.rs
+++ b/src/ui/terminal/keys.rs
@@ -230,7 +230,7 @@ derive_csi_sequence!(
 
 derive_csi_sequence!(
     #[doc = "Empty struct with a Display implementation that returns the byte sequence to end [Bracketed Paste Mode](http://www.xfree86.org/current/ctlseqs.html#Bracketed%20Paste%20Mode)"]
-    (BracketModeEnd, "?2003l")
+    (BracketModeEnd, "?2004l")
 );
 
 pub const BRACKET_PASTE_START: &[u8] = b"\x1B[200~";


### PR DESCRIPTION
Fix CSI code to end bracketed paste mode.
This fixes #12.